### PR TITLE
13_記事を表現するArticleモデルを追加

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -33,6 +33,9 @@ gem "rack-cors"
 # rails本体（標準gem）
 gem "rails", "~> 7.0.4"
 
+# メッセージを日本語化
+gem "rails-i18n"
+
 # タイムゾーン情報を提供する（標準gem）
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -199,6 +199,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.8.1)
       actionpack (= 7.0.8.1)
       activesupport (= 7.0.8.1)
@@ -293,6 +296,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.4)
+  rails-i18n
   rspec-rails
   rubocop-faker
   rubocop-rails

--- a/rails/app/models/article.rb
+++ b/rails/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < ApplicationRecord
+end

--- a/rails/app/models/article.rb
+++ b/rails/app/models/article.rb
@@ -1,2 +1,3 @@
 class Article < ApplicationRecord
+  belongs_to :user
 end

--- a/rails/app/models/article.rb
+++ b/rails/app/models/article.rb
@@ -1,3 +1,9 @@
 class Article < ApplicationRecord
   belongs_to :user
+
+  enum :status, {
+    unsaved: 10,
+    draft: 20,
+    published: 30,
+  }, _prefix: true
 end

--- a/rails/app/models/article.rb
+++ b/rails/app/models/article.rb
@@ -6,4 +6,15 @@ class Article < ApplicationRecord
     draft: 20,
     published: 30,
   }, _prefix: true
+
+  validates :title, :content, presence: true, if: :published?
+  validate :verify_only_one_unsaved_status_is_allowed
+
+  private
+
+    def verify_only_one_unsaved_status_is_allowed
+      if unsaved? && user.articles.unsaved.present?
+        raise StandardError, "未保存の記事は複数保有できません"
+      end
+    end
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :confirmable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :articles, dependent: :destroy
 end

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -36,5 +36,6 @@ module Myapp
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml").to_s]
   end
 end

--- a/rails/config/locales/ja.yml
+++ b/rails/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activerecord:
+    attributes:
+      article:
+        title: タイトル
+        content: 本文

--- a/rails/db/migrate/20240407031605_create_articles.rb
+++ b/rails/db/migrate/20240407031605_create_articles.rb
@@ -1,0 +1,12 @@
+class CreateArticles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :articles do |t|
+      t.string     :title,   comment: "タイトル"
+      t.text       :content, comment: "本文"
+      t.integer    :status,  comment: "ステータス（10:未保存, 20:下書き, 30:公開中）"
+      t.references :user,    null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_04_111522) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_07_031605) do
+  create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title", comment: "タイトル"
+    t.text "content", comment: "本文"
+    t.integer "status", comment: "ステータス（10:未保存, 20:下書き, 30:公開中）"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -36,4 +46,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_04_111522) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "articles", "users"
 end

--- a/rails/spec/factories/articles.rb
+++ b/rails/spec/factories/articles.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :article do
+    user
+    title { Faker::Lorem.sentence }
+    content { Faker::Lorem.paragraph }
+    status { :published }
+  end
+end

--- a/rails/spec/models/article_spec.rb
+++ b/rails/spec/models/article_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Article, type: :model do
+  describe "Validations" do
+    subject { article.valid? }
+
+    let(:user) { create(:user) }
+    let(:status) { :published }
+    let(:content) { Faker::Lorem.paragraph }
+    let(:title) { Faker::Lorem.sentence }
+    let(:article) { build(:article, title:, content:, status:, user:) }
+
+    context "factoryのデフォルト設定に従った時" do
+      it "正常にレコードを新規作成できる" do
+        expect {
+          create(:article)
+        }.to change { Article.count }.by(1)
+      end
+    end
+
+    context "全ての値が正常な時" do
+      it "検証が通る" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "ステータスが公開済みかつ、タイトルが空の時" do
+      let(:title) { "" }
+
+      it "エラーメッセージが返る" do
+        expect(subject).to eq false
+        expect(article.errors.full_messages).to eq ["タイトルを入力してください"]
+      end
+    end
+
+    context "ステータスが公開済みかつ、本文が空の時" do
+      let(:content) { "" }
+
+      it "エラーメッセージが返る" do
+        expect(subject).to be_falsy
+        expect(article.errors.full_messages).to eq ["本文を入力してください"]
+      end
+    end
+
+    context "ステータスが未保存かつ、すでに同一ユーザーが未保存ステータスの記事を所有していた時" do
+      let(:status) { :unsaved }
+
+      before { create(:article, status: :unsaved, user:) }
+
+      it "例外が発生する" do
+        expect { subject }.to raise_error(StandardError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応内容
- Articleモデルを追加
- i18n追加・設定
- user has_many articles, article belongs_to user
- model_spec
　

## 対応しなかったこと
- 
　

## 影響範囲
- model追加に留めたためなし
　

## テスト方法
URL:

- [ ] 追加したrspecがlocalでも通ること
　

## テスト観点
- モデル設計が適切か
　

## 補足事項

　

## その他
