### PR TITLE
14_記事一覧、詳細を取得可能にする

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -21,6 +21,9 @@ gem "devise-i18n"
 # ユーザーのトークン認証を提供する
 gem "devise_token_auth"
 
+# ページネーション機能を提供する
+gem "kaminari"
+
 # MySQLに接続する
 gem "mysql2", "~> 0.5"
 

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -43,6 +43,9 @@ gem "rails-i18n"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do
+  # N+1発生時にアラートを表示する
+  gem "bullet"
+
   # テスト用データを作成する
   gem "factory_bot_rails"
   gem "faker"

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -116,6 +116,18 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     jsonapi-renderer (0.2.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     launchy (3.0.0)
       addressable (~> 2.8)
@@ -288,6 +300,7 @@ DEPENDENCIES
   devise_token_auth
   factory_bot_rails
   faker
+  kaminari
   letter_opener_web
   mysql2 (~> 0.5)
   pry-byebug

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.1.6)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
@@ -280,6 +283,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.7.6)
@@ -294,6 +298,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   bootsnap
+  bullet
   config
   devise
   devise-i18n

--- a/rails/app/controllers/api/v1/articles_controller.rb
+++ b/rails/app/controllers/api/v1/articles_controller.rb
@@ -1,7 +1,9 @@
 class Api::V1::ArticlesController < ApplicationController
+  include Pagination
+
   def index
     articles = Article.preload(:user).published.order_by_newest.page(params[:page] || 1).per(10)
-    render json: articles
+    render json: articles, meta: pagination(articles), adapter: :json
   end
 
   def show

--- a/rails/app/controllers/api/v1/articles_controller.rb
+++ b/rails/app/controllers/api/v1/articles_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::ArticlesController < ApplicationController
+  def index
+    articles = Article.published.order_by_newest.page(params[:page] || 1).per(10)
+    render json: articles
+  end
+
   def show
     article = Article.published.find(params[:id])
     render json: article

--- a/rails/app/controllers/api/v1/articles_controller.rb
+++ b/rails/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < ApplicationController
+  def show
+    article = Article.published.find(params[:id])
+    render json: article
+  end
+end

--- a/rails/app/controllers/api/v1/articles_controller.rb
+++ b/rails/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ArticlesController < ApplicationController
   def index
-    articles = Article.published.order_by_newest.page(params[:page] || 1).per(10)
+    articles = Article.preload(:user).published.order_by_newest.page(params[:page] || 1).per(10)
     render json: articles
   end
 

--- a/rails/app/controllers/concerns/pagination.rb
+++ b/rails/app/controllers/concerns/pagination.rb
@@ -1,0 +1,10 @@
+module Pagination
+  extend ActiveSupport::Concern
+
+  def pagination(records)
+    {
+      current_page: records.current_page, # 現在のページ数
+      total_pages: records.total_pages, # 全体のページ数
+    }
+  end
+end

--- a/rails/app/models/article.rb
+++ b/rails/app/models/article.rb
@@ -1,6 +1,8 @@
 class Article < ApplicationRecord
   belongs_to :user
 
+  scope :order_by_newest, -> { order(created_at: :desc) }
+
   enum :status, {
     unsaved: 10,
     draft: 20,

--- a/rails/app/serializers/article_serializer.rb
+++ b/rails/app/serializers/article_serializer.rb
@@ -1,5 +1,6 @@
 class ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :content, :created_at, :from_today
+  belongs_to :user, serializer: UserSerializer
 
   def created_at
     object.created_at.strftime("%Y/%m/%d")

--- a/rails/app/serializers/article_serializer.rb
+++ b/rails/app/serializers/article_serializer.rb
@@ -1,0 +1,31 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :content, :created_at, :from_today
+
+  def created_at
+    object.created_at.strftime("%Y/%m/%d")
+  end
+
+  def from_today # rubocop:disable Metrics/AbcSize
+    now = Time.zone.now
+    created_at = object.created_at
+
+    months = (now.year - created_at.year) * 12 + now.month - created_at.month - ((now.day >= created_at.day) ? 0 : 1)
+    years = months.div(12)
+
+    return "#{years}年前" if years > 0
+    return "#{months}ヶ月前" if months > 0
+
+    seconds = (Time.zone.now - object.created_at).round
+
+    days = seconds / (60 * 60 * 24)
+    return "#{days}日前" if days.positive?
+
+    hours = seconds / (60 * 60)
+    return "#{hours}時間前" if hours.positive?
+
+    minutes = seconds / 60
+    return "#{minutes}分前" if minutes.positive?
+
+    "#{seconds}秒前"
+  end
+end

--- a/rails/app/serializers/user_serializer.rb
+++ b/rails/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :name
+end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       namespace :current do
         resource :user, only: [:show]
       end
-      resources :articles, only: [:show]
+      resources :articles, only: [:index, :show]
     end
   end
 end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       namespace :current do
         resource :user, only: [:show]
       end
+      resources :articles, only: [:show]
     end
   end
 end

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -5,3 +5,13 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+ActiveRecord::Base.transaction do
+  user1 = User.create!(name: "テスト太郎", email: "test1@example.com", password: "password", confirmed_at: Time.current)
+  user2 = User.create!(name: "テスト次郎", email: "test2@example.com", password: "password", confirmed_at: Time.current)
+
+  15.times do |i|
+    Article.create!(title: "テストタイトル1-#{i}", content: "テスト本文1-#{i}", status: :published, user: user1)
+    Article.create!(title: "テストタイトル2-#{i}", content: "テスト本文2-#{i}", status: :published, user: user2)
+  end
+end

--- a/rails/spec/requests/api/v1/articles_spec.rb
+++ b/rails/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/rails/spec/requests/api/v1/articles_spec.rb
+++ b/rails/spec/requests/api/v1/articles_spec.rb
@@ -1,7 +1,84 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "GET api/v1/articles" do
+    subject { get(api_v1_articles_path(params)) }
+
+    before do
+      create_list(:article, 25, status: :published)
+      create_list(:article, 8, status: :draft)
+    end
+
+    context "page を params で送信しない時" do
+      let(:params) { nil }
+
+      it "1ページ目のレコード10件取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.keys).to eq ["articles", "meta"]
+        expect(res["articles"].length).to eq 10
+        expect(res["articles"][0].keys).to eq ["id", "title", "content", "created_at", "from_today", "user"]
+        expect(res["articles"][0]["user"].keys).to eq ["name"]
+        expect(res["meta"].keys).to eq ["current_page", "total_pages"]
+        expect(res["meta"]["current_page"]).to eq 1
+        expect(res["meta"]["total_pages"]).to eq 3
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "page を params で送信した時" do
+      let(:params) { { page: 2 } }
+
+      it "該当ページ目のレコード10件取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.keys).to eq ["articles", "meta"]
+        expect(res["articles"].length).to eq 10
+        expect(res["articles"][0].keys).to eq ["id", "title", "content", "created_at", "from_today", "user"]
+        expect(res["articles"][0]["user"].keys).to eq ["name"]
+        expect(res["meta"].keys).to eq ["current_page", "total_pages"]
+        expect(res["meta"]["current_page"]).to eq 2
+        expect(res["meta"]["total_pages"]).to eq 3
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET api/v1/articles/:id" do
+    subject { get(api_v1_article_path(article_id)) }
+
+    let(:article) { create(:article, status:) }
+
+    context "article_id に対応する articles レコードが存在する時" do
+      let(:article_id) { article.id }
+
+      context "articles レコードのステータスが公開中の時" do
+        let(:status) { :published }
+
+        it "正常にレコードを取得できる" do
+          subject
+          res = JSON.parse(response.body)
+          expect(res.keys).to eq ["id", "title", "content", "created_at", "from_today", "user"]
+          expect(res["user"].keys).to eq ["name"]
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "articles レコードのステータスが下書きの時" do
+        let(:status) { :draft }
+
+        it "ActiveRecord::RecordNotFound エラーが返る" do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+
+    context "article_id に対応する articles レコードが存在しない時" do
+      let(:article_id) { 10_000_000_000 }
+
+      it "ActiveRecord::RecordNotFound エラーが返る" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 対応内容
- articles_controllerにて、#index, #showの定義
- indexにて、paginatioinを利用できるようにした
　

## 対応しなかったこと
- 
　

## 影響範囲
- 
　

## テスト方法
- 事前準備
```
rails db:migrate:reset
rails db:seed
```

- [ ] http://localhost:3000/api/v1/articles にて、記事一覧が取得できること
- [ ] http://localhost:3000/api/v1/articles?page=2 にて、ページネーションが行われた記事一覧が取得できること
- [ ] http://localhost:3000/api/v1/articles/:id にて、記事詳細が取得できること
　

## テスト観点
- 
　

## 補足事項
- 
　

## その他
